### PR TITLE
Improve Replugged workflow + how to

### DIFF
--- a/.github/workflows/rp.yml
+++ b/.github/workflows/rp.yml
@@ -32,7 +32,12 @@ jobs:
       - name: Build TypeScript and bundle into asar
         run: pnpm run rp
 
-      - uses: ncipollo/release-action@v1
+      - name: Build BD .theme.css
+        run: pnpm run bd
+
+      - name: Publish release
+        uses: ncipollo/release-action@v1
         with:
-          artifacts: "bundle/*"
+          artifacts: "bundle/*, dist/*.theme.css"
           makeLatest: true
+          generateReleaseNotes: true


### PR DESCRIPTION
This is a minor update to the Replugged workflow - it now also adds the BD .theme.css file to the release automatically.

Also, since the Replugged installer/updater only works on releases published via GitHub Actions (not manually created releases), here's notes on how the workflow behaves:
- The workflow will fail if there's already a release existing on the same tag, eg. if you manually create a release before the workflow completes. Let the workflow create the release, then edit the title / release notes afterwards.
- If you tagged a previous commit with a version that you now want to use again, do the following:
    1. Delete the tag on your machine: `git tag -d tagname`
    2. Delete the tag from github: `git push --delete origin tagname`
        - Warning, this also completely deletes the release associated with the tag, recommend copying the release notes somewhere else beforehand.
    4. Create the tag again.
