### PR TITLE
Self Messages Update to Work w/ Vencord

### DIFF
--- a/src/addon/_selfmessages.scss
+++ b/src/addon/_selfmessages.scss
@@ -1,7 +1,7 @@
 /** 
  * Selfmessages. Heavily based on Discord 11's Message bubbles
  * Message Bubbles
- * Modified by x3non to work with Vencord
+ * Modified (for Virtual Boy) by x3non to work in Vencord
  */
 
 #app-mount [class^="messageListItem__"][data-is-self="true"] {
@@ -131,7 +131,7 @@
     background-color: var(--background-mentioned-hover);
 
 #app-mount .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64::before {
-	background-color: var(--info-warning-foreground);
+    background-color: var(--info-warning-foreground);
     content: "";
     position: absolute;
     display: block;
@@ -145,7 +145,7 @@
 }
 
 #app-mount .repliedMessage__636d2 {
-	background-color: var(--background-mentioned-hover);
+    background-color: var(--background-message-hover);
     padding: 6px;
     width: fit-content;
     max-width: 100%;

--- a/src/addon/_selfmessages.scss
+++ b/src/addon/_selfmessages.scss
@@ -1,122 +1,137 @@
-//Selfmessages. Heavily based on Discord 11's Message bubbles
-/* Message Bubbles*/
-#app-mount .selfmessage {
+/** 
+ * Selfmessages. Heavily based on Discord 11's Message bubbles
+ * Message Bubbles
+ * Modified by x3non to work with Vencord
+ */
+
+#app-mount [class^="messageListItem__"][data-is-self="true"] {
     margin-left: auto;
     width: auto;
     padding-left: 48px;
     padding-right: 72px !important;
 }
 
-#app-mount .selfmessage .container_dbadf5 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .container__62863 {
     direction: rtl;
+	text-align: right;
+	padding-right: 8px;
 }
 
-#app-mount .selfmessage .contents_f41bb2 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c:not(.markup_a7e664) {
+	text-align: right;
+	padding-right: 8px;
+}
+
+#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c > .contents_d3ae0d > .markup_a7e664  {
+	text-align: left;
+}
+
+#app-mount [class^="messageListItem__"][data-is-self="true"] .contents_d3ae0d {
     display: block;
     width: fit-content;
     margin-left: auto;
     margin-right: 8px;
 }
-#app-mount .message__80c10.selected_fd9051[data-is-author-self="true"] .contents_f41bb2 {
+
+#app-mount [class^="messageListItem__"][data-is-self="true"].message_ccca67.selected_e3bc5d .contents_d3ae0d {
     width: 100%;
 }
 
-#app-mount .selfmessage .timestamp_cdbd93 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .timestamp_c79dd2 {
     left: unset;
     right: 8px;
-}
-#app-mount .selfmessage .repliedMessage_e2bf4a {
-    margin-left: auto;
+	margin-top: 1.75px;
 }
 
-#app-mount .replying_d7b6ad[data-is-author-self="true"] .contents_f41bb2 .messageContent__21e69::before,
-#app-mount .mentioned__58017[data-is-author-self="true"] .contents_f41bb2 .messageContent__21e69::before {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .replying__38514 .contents_d3ae0d .messageContent_abea64::before,
+#app-mount [class^="messageListItem__"][data-is-self="true"] .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64::before {
     left: unset;
     right: 0;
 }
 
-#app-mount .selfmessage .contents_f41bb2 .messageContent__21e69 {
-    margin-left: auto;
-    background-color: black !important;
-}
-#app-mount .selfmessage a:not(.embed_d3cbe3 .embedAuthorNameLink_b25226) {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .contents_d3ae0d .messageContent_abea64,
+#app-mount [class^="messageListItem__"][data-is-self="true"] a:not(.embed_cc6dae .embedAuthorNameLink_dd0d5f),
+#app-mount [class^="messageListItem__"][data-is-self="true"] .repliedMessage__636d2 {
     margin-left: auto;
 }
 
-#app-mount .selfmessage .embedAuthor_cb4bfc {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .embedAuthor__3e899 {
     direction: ltr;
 }
 
-#app-mount .selfmessage .avatar__08316 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .avatar__08316 {
     left: unset;
-    right: 16px;
+    right: 4px;
 }
 
-#app-mount .selfmessage .header__39b23 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .header__6a14d {
     display: flex;
     flex-direction: row-reverse;
 }
-#app-mount .selfmessage .header__39b23 span {
+
+#app-mount [class^="messageListItem__"][data-is-self="true"] .header__6a14d span {
     margin-left: 0.25rem;
     margin-right: unset;
 }
 
-#app-mount .selfmessage .repliedMessage_e2bf4a:before {
-    display: none;
-}
-
-#app-mount .contents_f41bb2 > .messageContent__21e69 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] > .messageContent_abea64 {
     overflow: visible;
 }
 
-#app-mount .contents_f41bb2 pre {
+#app-mount [class^="messageListItem__"][data-is-self="true"] pre {
     max-width: 100%;
 }
 
-#app-mount .contents_f41bb2 .messageContent__21e69 {
-    background-color: black !important;
+#app-mount .contents_d3ae0d .messageContent_abea64 {
+	background-color: black !important;
     padding: 8px;
     margin-left: unset;
-    border-radius: 0px;
     width: fit-content;
+	max-width: 750px;
 }
-#app-mount .contents_f41bb2 {
+
+#app-mount .contents_d3ae0d .messageContent_abea64 > [class^="markup_"]{
+	max-width: 750px;
+}
+
+#app-mount .contents_d3ae0d {
     display: inline-block;
     max-width: 100%;
 }
-#app-mount .message__80c10 {
+
+#app-mount .message_ccca67 {
     max-width: 100%;
 }
-#app-mount .message__80c10:hover:not(.replying_d7b6ad):not(.mentioned__58017) .contents_f41bb2 .messageContent__21e69,
-#app-mount .message__80c10.selected_fd9051:not(.replying_d7b6ad):not(.mentioned__58017) .contents_f41bb2 .messageContent__21e69 {
+
+#app-mount .message_ccca67:hover:not(.replying__38514):not(.mentioned_fa6fd2) .contents_d3ae0d .messageContent_abea64,
+#app-mount .message_ccca67.selected_e3bc5d:not(.replying__38514):not(.mentioned_fa6fd2) .contents_d3ae0d .messageContent_abea64 {
     background-color: black !important;
 }
 
-#app-mount .message__80c10.compact__54ecc.wrapper__09ecc[data-is-author-self="true"] .messageContent__21e69 {
+#app-mount .message_ccca67.compact_eda3c8.wrapper_a62503 .messageContent_abea64 {
     display: flex;
 }
 
-#app-mount .compact__54ecc.wrapper__09ecc {
+#app-mount .compact_eda3c8.wrapper_a62503 {
     padding-top: 8px;
     padding-bottom: 8px;
 }
 
-#app-mount .mentioned__58017.compact__54ecc .contents_f41bb2 .messageContent__21e69::before:not([data-is-author-self="true"]) {
-    left: 4px;
-}
-#app-mount .replying_d7b6ad.compact__54ecc .contents_f41bb2 .messageContent__21e69::before:not([data-is-author-self="true"]) {
+#app-mount .mentioned_fa6fd2.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([class^="messageListItem__"][data-is-self="true"]),
+#app-mount .replying__38514.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([class^="messageListItem__"][data-is-self="true"]) {
     left: 4px;
 }
 
-#app-mount .mentioned__58017 .contents_f41bb2 .messageContent__21e69 {
+#app-mount .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64 {
     background-color: var(--background-mentioned);
 }
-#app-mount .mentioned__58017:hover .contents_f41bb2 .messageContent__21e69,
-#app-mount .mentioned__58017.selected_fd9051 .contents_f41bb2 .messageContent__21e69 {
+
+#app-mount .mentioned_fa6fd2:hover .contents_d3ae0d .messageContent_abea64,
+#app-mount .mentioned_fa6fd2.selected_e3bc5d .contents_d3ae0d .messageContent_abea64 {
     background-color: var(--background-mentioned-hover);
-}
-#app-mount .mentioned__58017 .contents_f41bb2 .messageContent__21e69::before {
-    background-color: var(--info-warning-foreground);
+
+#app-mount .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64::before {
+	background-color: var(--info-warning-foreground);
     content: "";
     position: absolute;
     display: block;
@@ -126,30 +141,26 @@
     pointer-events: none;
     width: 3px;
     margin: 8px 0;
-    border-radius: 0;
     z-index: 1;
 }
-#app-mount .mentioned__58017:before {
-    display: none;
-}
 
-#app-mount .repliedMessage_e2bf4a {
-    background-color: var(--background-message-hover);
+#app-mount .repliedMessage__636d2 {
+	background-color: var(--background-mentioned-hover);
     padding: 6px;
-    border-radius: 0;
     width: fit-content;
     max-width: 100%;
 }
 
-#app-mount .replying_d7b6ad .contents_f41bb2 .messageContent__21e69 {
+#app-mount .replying__38514 .contents_d3ae0d .messageContent_abea64 {
     background-color: var(--brand-experiment-05a);
 }
-#app-mount .replying_d7b6ad:hover .contents_f41bb2 .messageContent__21e69,
-#app-mount .replying_d7b6ad.selected_fd9051 .contents_f41bb2 .messageContent__21e69 {
+
+#app-mount .replying__38514:hover .contents_d3ae0d .messageContent_abea64,
+#app-mount .replying__38514.selected_e3bc5d .contents_d3ae0d .messageContent_abea64 {
     background-color: var(--brand-experiment-10a);
-}
-#app-mount .replying_d7b6ad .contents_f41bb2 .messageContent__21e69::before {
-    background-color: var(--brand-experiment);
+
+#app-mount .replying__38514 .contents_d3ae0d .messageContent_abea64::before {
+	background-color: var(--brand-experiment);
     content: "";
     position: absolute;
     display: block;
@@ -159,15 +170,18 @@
     pointer-events: none;
     width: 3px;
     margin: 8px 0;
-    border-radius: 0;
     z-index: 1;
 }
-.replying_d7b6ad:before {
+
+#app-mount [class^="messageListItem__"][data-is-self="true"] .repliedMessage__636d2:before,
+#app-mount .mentioned_fa6fd2:before,
+.replying__38514:before,
+.repliedMessage__636d2:before,
+.spine_d081ec.cozy__0c529,
+.message_ccca67::after {
     display: none;
 }
-.repliedMessage_e2bf4a:before {
-    display: none;
-}
+
 [class*="markup-"][class*="messageContent-"]:not([class*="repliedTextPreview-"][class*="clickable-"] > div) {
     background: linear-gradient(to right, black, black) !important;
 }

--- a/src/addon/_selfmessages.scss
+++ b/src/addon/_selfmessages.scss
@@ -163,10 +163,6 @@
     border-radius: 1.5px;
     z-index: 1;
   }
-
-  #app-mount .mentioned_fa6fd2:before {
-    display: none;
-  }
   
   #app-mount .repliedMessage__636d2 {
     background-color: var(--background-message-hover);

--- a/src/addon/_selfmessages.scss
+++ b/src/addon/_selfmessages.scss
@@ -1,84 +1,105 @@
 /** 
  * Selfmessages. Heavily based on Discord 11's Message bubbles
  * Message Bubbles
- * Modified (for Virtual Boy) by x3non to work in Vencord
+ * Modified by x3non to work with Vencord
  */
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] {
+#app-mount [class^="messageListItem__"][data-is-self="true"],
+#app-mount .selfmessage {
     margin-left: auto;
     width: auto;
     padding-left: 48px;
-    padding-right: 72px !important;
+    padding-right: 16px !important;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .container__62863 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .container__62863,
+#app-mount .selfmessage .container__62863 {
     direction: rtl;
 	text-align: right;
 	padding-right: 8px;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c:not(.markup_a7e664) {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c:not(.markup_a7e664), {
 	text-align: right;
 	padding-right: 8px;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c > .contents_d3ae0d > .markup_a7e664  {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c > .contents_d3ae0d > .markup_a7e664,
+#app-mount .selfmessage .groupStart__7b93c > .contents_d3ae0d > .markup_a7e664  {
 	text-align: left;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .contents_d3ae0d {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .contents_d3ae0d,
+#app-mount .selfmessage .contents_d3ae0d {
     display: block;
     width: fit-content;
     margin-left: auto;
     margin-right: 8px;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"].message_ccca67.selected_e3bc5d .contents_d3ae0d {
+#app-mount [class^="messageListItem__"][data-is-self="true"].message_ccca67.selected_e3bc5d .contents_d3ae0d,
+#app-mount .message_ccca67.selected_e3bc5d[data-is-author-self="true"] .contents_d3ae0d {
     width: 100%;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .timestamp_c79dd2 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .timestamp_c79dd2,
+#app-mount .selfmessage .timestamp_c79dd2 {
     left: unset;
     right: 8px;
 	margin-top: 1.75px;
 }
 
 #app-mount [class^="messageListItem__"][data-is-self="true"] .replying__38514 .contents_d3ae0d .messageContent_abea64::before,
-#app-mount [class^="messageListItem__"][data-is-self="true"] .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64::before {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64::before,
+#app-mount .replying__38514[data-is-author-self="true"] .contents_d3ae0d .messageContent_abea64::before,
+#app-mount .mentioned_fa6fd2[data-is-author-self="true"] .contents_d3ae0d .messageContent_abea64::before {
     left: unset;
     right: 0;
 }
 
 #app-mount [class^="messageListItem__"][data-is-self="true"] .contents_d3ae0d .messageContent_abea64,
+#app-mount .selfmessage .contents_d3ae0d .messageContent_abea64 {
+    margin-left: auto;
+    background-color: black !important;
+}
+
 #app-mount [class^="messageListItem__"][data-is-self="true"] a:not(.embed_cc6dae .embedAuthorNameLink_dd0d5f),
-#app-mount [class^="messageListItem__"][data-is-self="true"] .repliedMessage__636d2 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .repliedMessage__636d2,
+#app-mount .selfmessage a:not(.embed_cc6dae .embedAuthorNameLink_dd0d5f),
+#app-mount .selfmessage .repliedMessage__636d2  {
     margin-left: auto;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .embedAuthor__3e899 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .embedAuthor__3e899,
+#app-mount .selfmessage .embedAuthor__3e899 {
     direction: ltr;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .avatar__08316 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .avatar__08316,
+#app-mount .selfmessage .avatar__08316 {
     left: unset;
     right: 4px;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .header__6a14d {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .header__6a14d,
+#app-mount .selfmessage .header__6a14d {
     display: flex;
     flex-direction: row-reverse;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .header__6a14d span {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .header__6a14d span,
+#app-mount .selfmessage .header__6a14d span {
     margin-left: 0.25rem;
     margin-right: unset;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] > .messageContent_abea64 {
+#app-mount [class^="messageListItem__"][data-is-self="true"] > .messageContent_abea64,
+#app-mount .selfmessage > .messageContent_abea64 {
     overflow: visible;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] pre {
+#app-mount [class^="messageListItem__"][data-is-self="true"] pre,
+#app-mount .selfmessage pre {
     max-width: 100%;
 }
 
@@ -118,7 +139,9 @@
 }
 
 #app-mount .mentioned_fa6fd2.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([class^="messageListItem__"][data-is-self="true"]),
-#app-mount .replying__38514.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([class^="messageListItem__"][data-is-self="true"]) {
+#app-mount .replying__38514.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([class^="messageListItem__"][data-is-self="true"]),
+#app-mount .mentioned_fa6fd2.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([data-is-author-self="true"]),
+#app-mount .replying__38514.compact_eda3c8 .contents_d3ae0d .messageContent_abea64::before:not([data-is-author-self="true"]) {
     left: 4px;
 }
 
@@ -129,9 +152,10 @@
 #app-mount .mentioned_fa6fd2:hover .contents_d3ae0d .messageContent_abea64,
 #app-mount .mentioned_fa6fd2.selected_e3bc5d .contents_d3ae0d .messageContent_abea64 {
     background-color: var(--background-mentioned-hover);
+}
 
 #app-mount .mentioned_fa6fd2 .contents_d3ae0d .messageContent_abea64::before {
-    background-color: var(--info-warning-foreground);
+	background-color: var(--info-warning-foreground);
     content: "";
     position: absolute;
     display: block;
@@ -145,7 +169,7 @@
 }
 
 #app-mount .repliedMessage__636d2 {
-    background-color: var(--background-message-hover);
+	background-color: var(--background-mentioned-hover);
     padding: 6px;
     width: fit-content;
     max-width: 100%;
@@ -158,6 +182,7 @@
 #app-mount .replying__38514:hover .contents_d3ae0d .messageContent_abea64,
 #app-mount .replying__38514.selected_e3bc5d .contents_d3ae0d .messageContent_abea64 {
     background-color: var(--brand-experiment-10a);
+}
 
 #app-mount .replying__38514 .contents_d3ae0d .messageContent_abea64::before {
 	background-color: var(--brand-experiment);
@@ -174,6 +199,7 @@
 }
 
 #app-mount [class^="messageListItem__"][data-is-self="true"] .repliedMessage__636d2:before,
+#app-mount .selfmessage .repliedMessage__636d2:before,
 #app-mount .mentioned_fa6fd2:before,
 .replying__38514:before,
 .repliedMessage__636d2:before,

--- a/src/addon/_selfmessages.scss
+++ b/src/addon/_selfmessages.scss
@@ -19,7 +19,8 @@
 	padding-right: 8px;
 }
 
-#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c:not(.markup_a7e664), {
+#app-mount [class^="messageListItem__"][data-is-self="true"] .groupStart__7b93c:not(.markup_a7e664),
+#app-mount .selfmessage .groupStart__7b93c:not(.markup_a7e664){
 	text-align: right;
 	padding-right: 8px;
 }


### PR DESCRIPTION
I updated the "SelfMessages" addon to work with Vencord (w/ ThemeAttributes Plugin on).
I also made a personal version of it to work with (possibly) any theme.
- I made the personal version first before I modified it for Virtual Boy. I made it a [CSS snippet](https://github.com/its-x3non/DiscordSnippets/tree/main/CSS%20Addons/Right%20Align%20Self%20Messages).

Here's a screenshot of it working w/ Vencord:
![image](https://github.com/Riddim-GLiTCH/Virtual-Boy/assets/87145730/16d4ebdf-109d-479a-ad8a-5797c68539df)
